### PR TITLE
Potential fix for code scanning alert no. 3: Use of password hash with insufficient computational effort

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,20 +6,18 @@
 // Container for all the Helpers
 
 //Dependencies
-const crypto = require("crypto");
+const bcrypt = require("bcrypt");
 const config = require("./config");
 const path = require("path");
 const fs = require("fs");
 
 const helpers = {};
 
-// Create a SHA256 hash
+// Create a bcrypt hash
 helpers.hash = function (str) {
   if (typeof str == "string" && str.length > 0) {
-    const hash = crypto
-      .createHmac("sha256", config.hashingSecret)
-      .update(str)
-      .digest("hex");
+    const saltRounds = 10;
+    const hash = bcrypt.hashSync(str, saltRounds);
     return hash;
   } else return false;
 };

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "utf-8-validate": "^5.0.5",
     "ws": "^8.18.0",
     "xhr": "^2.6.0",
-    "xmlhttprequest": "^1.8.0"
+    "xmlhttprequest": "^1.8.0",
+    "bcrypt": "^5.1.1"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/avifenesh/emailSender/security/code-scanning/3](https://github.com/avifenesh/emailSender/security/code-scanning/3)

To fix the problem, we need to replace the insecure SHA256 hashing with a more secure password hashing algorithm like bcrypt. This involves updating the `helpers.hash` function to use bcrypt instead of SHA256. We will also need to add the bcrypt library to the project.

1. Install the bcrypt library.
2. Update the `helpers.hash` function to use bcrypt for hashing passwords.
3. Ensure that the rest of the code that relies on the `helpers.hash` function continues to work as expected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
