### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -134,13 +134,18 @@ helpers.getStaticAsset = function (fileName, callback) {
     typeof fileName == "string" && fileName.length > 0 ? fileName : false;
   if (fileName) {
     const publicDir = path.join(__dirname, "/../public/");
-    fs.readFile(publicDir + fileName, function (err, data) {
-      if (!err && data) {
-        callback(false, data);
-      } else {
-        callback("No file could be found");
-      }
-    });
+    const resolvedPath = path.resolve(publicDir, fileName);
+    if (resolvedPath.startsWith(publicDir)) {
+      fs.readFile(resolvedPath, function (err, data) {
+        if (!err && data) {
+          callback(false, data);
+        } else {
+          callback("No file could be found");
+        }
+      });
+    } else {
+      callback("Invalid file path");
+    }
   } else {
     callback("A valid file name was not specified");
   }


### PR DESCRIPTION
Potential fix for [https://github.com/avifenesh/emailSender/security/code-scanning/2](https://github.com/avifenesh/emailSender/security/code-scanning/2)

To fix the problem, we need to ensure that the `fileName` is validated and sanitized before it is used to construct file paths. We can achieve this by normalizing the path using `path.resolve` and ensuring it is contained within the intended directory. This will prevent path traversal attacks.

1. Normalize the `fileName` using `path.resolve` to remove any `..` segments.
2. Check that the normalized path starts with the intended directory (`publicDir`).
3. If the path is valid, proceed with reading the file; otherwise, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
